### PR TITLE
Fix validation of ingredients with decimal quantities

### DIFF
--- a/src/js/sanitize.js
+++ b/src/js/sanitize.js
@@ -165,7 +165,7 @@ function sanitizeIngredient (ingredient) {
 
   // only set properties for the capture groups which ended up matching.
   if (match) {
-    const ret = {}
+    const ret = {};
     match[1] && (ret.quantity = match[1]);
     match[2] && (ret.unit = match[2]);
     match[3] && (ret.ingredient = match[3]);

--- a/src/js/sanitize.js
+++ b/src/js/sanitize.js
@@ -152,7 +152,7 @@ const FRACTIONS = Object.values(FRACT_MAP).join('');
 // Try to match things like "1 tablespoon sugar"
 const RECIPE_QUANTITY_RE = new RegExp([
   '^',
-  `((?:(?:\\d+\\s?)?[\\d${FRACTIONS}⁄-]+)|(?:\\d*\.\\d+))`,
+  `((?\\.\\d+|\\d+(?:\\.\\d+))(?:\\s?[${FRACTIONS}])?)`,
   '\\s*',
   `(${UNITS.join('|')})?\\.?`,
   '\\s*',

--- a/src/js/sanitize.js
+++ b/src/js/sanitize.js
@@ -109,7 +109,7 @@ function sanitizeYield (yield_) {
     .toLowerCase();
 }
 
-const QUANTITIES = [
+const UNITS = [
   'ounce(?:s)?',
   'oz',
   'pound(?:s)?',
@@ -152,9 +152,9 @@ const FRACTIONS = Object.values(FRACT_MAP).join('');
 // Try to match things like "1 tablespoon sugar"
 const RECIPE_QUANTITY_RE = new RegExp([
   '^',
-  `((?:\\d+\\s?)?[\\d${FRACTIONS}⁄-]+)`,
+  `((?:(?:\\d+\\s?)?[\\d${FRACTIONS}⁄-]+)|(?:\\d*\.\\d+))`,
   '\\s*',
-  `(${QUANTITIES.join('|')})?\\.?`,
+  `(${UNITS.join('|')})?\\.?`,
   '\\s*',
   '(.*)',
   '$'

--- a/src/js/sanitize.js
+++ b/src/js/sanitize.js
@@ -154,7 +154,7 @@ const RECIPE_QUANTITY_RE = new RegExp([
   '^',
   `((?:\\.\\d+|\\d+(?:\\.\\d+)?)?(?:\\s*[${FRACTIONS}-])?(?:\\s*⁄\\d+)?)`,
   '\\s*',
-  `(${UNITS.join('|')})?`,
+  `(${UNITS.join('|')})?\\.?`,
   '\\s*',
   '(.*)',
   '$'

--- a/src/js/sanitize.js
+++ b/src/js/sanitize.js
@@ -152,9 +152,9 @@ const FRACTIONS = Object.values(FRACT_MAP).join('');
 // Try to match things like "1 tablespoon sugar"
 const RECIPE_QUANTITY_RE = new RegExp([
   '^',
-  `((?\\.\\d+|\\d+(?:\\.\\d+))(?:\\s?[${FRACTIONS}])?)`,
+  `((?:\\.\\d+|\\d+(?:\\.\\d+)?)?(?:\\s*[${FRACTIONS}-])?(?:\\s*⁄\\d+)?)`,
   '\\s*',
-  `(${UNITS.join('|')})?\\.?`,
+  `(${UNITS.join('|')})?`,
   '\\s*',
   '(.*)',
   '$'
@@ -163,11 +163,17 @@ const RECIPE_QUANTITY_RE = new RegExp([
 function sanitizeIngredient (ingredient) {
   const match = ingredient.match(RECIPE_QUANTITY_RE);
 
-  if (match === null) {
-    return {ingredient};
+  // only set properties for the capture groups which ended up matching.
+  if (match) {
+    const ret = {}
+    match[1] && (ret.quantity = match[1]);
+    match[2] && (ret.unit = match[2]);
+    match[3] && (ret.ingredient = match[3]);
+    return ret;
   }
 
-  return {quantity: match[1], unit: match[2], ingredient: match[3]};
+  // if the match failed completely, don't change anything
+  return {ingredient};
 }
 
 function sanitizeInstructions (instructions) {

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -100,15 +100,19 @@ describe('sanitize', () => {
       });
     });
 
-    
     it('handles decimals', () => {
       assert.deepEqual(sanitize.ingredient('0.5 cup potato'), {
 	quantity: '0.5',
 	unit: 'cup',
 	ingredient: 'potato'
       });
-    });
 
+      assert.deepEqual(sanitize.ingredient('0.5 cup potato'), {
+	quantity: '.5',
+	unit: 'cup',
+	ingredient: 'potato'
+      });      
+    });
 
     it('handles missing units', () => {
       assert.deepEqual(sanitize.ingredient('52 grapes'), {

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -120,6 +120,14 @@ describe('sanitize', () => {
         ingredient: 'grapes'
       });
     });
+
+    it('handles units with a a trailing period', () => {
+      assert.deepEqual(sanitize.ingredient('6 oz. olive oil'), {
+	quantity: '6',
+	unit: 'oz',
+	ingredient: 'olive oil',
+      });
+    });
   });
 
   describe('string', () => {

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -100,6 +100,16 @@ describe('sanitize', () => {
       });
     });
 
+    
+    it('handles decimals', () => {
+      assert.deepEqual(sanitize.ingredient('0.5 cup potato'), {
+	quantity: '0.5',
+	unit: 'cup',
+	ingredient: 'potato'
+      });
+    });
+
+
     it('handles missing units', () => {
       assert.deepEqual(sanitize.ingredient('52 grapes'), {
         quantity: '52',

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -107,7 +107,7 @@ describe('sanitize', () => {
 	ingredient: 'potato'
       });
 
-      assert.deepEqual(sanitize.ingredient('0.5 cup potato'), {
+      assert.deepEqual(sanitize.ingredient('.5 cup potato'), {
 	quantity: '.5',
 	unit: 'cup',
 	ingredient: 'potato'
@@ -117,7 +117,6 @@ describe('sanitize', () => {
     it('handles missing units', () => {
       assert.deepEqual(sanitize.ingredient('52 grapes'), {
         quantity: '52',
-        unit: null,
         ingredient: 'grapes'
       });
     });


### PR DESCRIPTION
This is based on PR #7.

Validation of recipe quantities now decimal quantities like `.y` and `x.y`.

Testing Done:
- npm run lint
- npm run test
- manual testing: https://www.allrecipes.com/recipe/76778/slow-cook-thai-chicken/ now shows `0.666... cups of creamy penut butter`, where before it was parsing incorrectly and rendering as `0 66666668653488 cup creamy penut butter`. 
- manual testing: https://www.allrecipes.com/recipe/57028/amazingly-good-eggnog/
- manual testing: https://cooking.nytimes.com/recipes/1016196-coconut-red-curry-with-tofu (recipe ingredient with missing unit).

Fixes #6 